### PR TITLE
add SITECLCD to FIA preprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,3 @@ scripts/data
 notebooks/fire/data
 notebooks/fire/scratch
 notebooks/biomass/data
-

--- a/carbonplan_forests/preprocess/fia.py
+++ b/carbonplan_forests/preprocess/fia.py
@@ -87,6 +87,7 @@ def preprocess_state(state_abbr, save=True):
         'SICOND',
         'SISP',
         'OWNCD',
+        'SITECLCD',
         'FORTYPCD',
         'FLDTYPCD',
         'DSTRBCD1',


### PR DESCRIPTION
it can be helpful (and sometimes essential!) to have condition site class code information. this change causes `SITECLCD` to be preserved in state level preprocessing. 