### PR TITLE
Exclude Phase I plots

### DIFF
--- a/carbonplan_forests/preprocess/fia.py
+++ b/carbonplan_forests/preprocess/fia.py
@@ -105,7 +105,9 @@ def preprocess_state(state_abbr, save=True):
     ]
 
     cond_agg = cond_df.groupby(['PLT_CN', 'CONDID'])[cond_vars].max()
-    cond_agg = cond_agg.join(plot_df.set_index('CN')[['LAT', 'LON', 'ELEV']], on='PLT_CN')
+    cond_agg = cond_agg.join(
+        plot_df[plot_df['PLOT_STATUS_CD'] != 2].set_index('CN')[['LAT', 'LON', 'ELEV']], on='PLT_CN'
+    )
 
     def dstrbcd_to_disturb_class(dstrbcd):
         """


### PR DESCRIPTION
According to FIA Phase II manual:

> FIA uses what may be characterized as a three-phase sampling scheme. Phase 1 (P1) is used for stratification, while Phase 2 (P2) consists of plots that are visited or photo-interpreted.
> A subset of Phase 2 plots are designated as Phase 3 (P3) plots (formerly known as Forest Health Monitoring [FHM] plots) where additional health indicator attributes are collected.

It appears that the data we downloaded includes both Phase I and Phase II plots! This distinction might be helpful for some sampling applications, for our current applications it means we end up carrying around a bunch of conditions that have `BALive` of either 0 or NaN. This PR removes those _sampled_ but _non-visited_ plots from downstream data products.